### PR TITLE
Fix incorrect flag in secret key generation error message

### DIFF
--- a/malai/src/main.rs
+++ b/malai/src/main.rs
@@ -136,7 +136,7 @@ fn resolve_secret_key_path(path_arg: Option<String>) -> Result<std::path::PathBu
 
     if !secret_key_path.exists() {
         eprintln!(
-            "Secret key file does not exist at {secret_key_path:?}. Please create it using `malai keygen {secret_key_path:?}` or provide a valid path."
+            "Secret key file does not exist at {secret_key_path:?}. Please create it using `malai keygen -p {secret_key_path:?}` or provide a valid path."
         );
         return Err(());
     }


### PR DESCRIPTION
This PR updates the error message shown when the secret key file is missing.
Previously, the message incorrectly suggested using `malai keygen {path}` to generate the key.
The correct usage is `malai keygen -p {path}`, and this has now been reflected in the error message.