### PR TITLE
ports in bridge command are optional now

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # ChangeLog
 
+## Unreleased
+
+### malai ??
+
+- `malai {http, tcp}-bridge`: `port` is now optional, if you don't provide a
+  port, it will be assigned a random port.
+- breaking: `malai tcp-bridge` accepts port using `--port` or `-p` flag. Earlier
+  it used to accept the port as second positional parameter. This is breaking
+  change and is done to be consistent with `malai http-bridge` command.
+
 ## 06 May 2025
 
 ### malai 0.2.3

--- a/malai/src/main.rs
+++ b/malai/src/main.rs
@@ -195,8 +195,6 @@ pub enum Command {
         #[arg(help = "The id52 to which this bridge will forward incoming TCP request.")]
         proxy_target: String,
         #[arg(
-            long,
-            short('p'),
             help = "The port on which this bridge will listen for incoming TCP requests. If you pass 0, it will bind to a random port.",
             default_value = "0"
         )]

--- a/malai/src/main.rs
+++ b/malai/src/main.rs
@@ -185,8 +185,8 @@ pub enum Command {
         #[arg(
             long,
             short('p'),
-            help = "The port on which this bridge will listen for incoming HTTP requests.",
-            default_value = "8080"
+            help = "The port on which this bridge will listen for incoming HTTP requests. If you pass 0, it will bind to a random port.",
+            default_value = "0"
         )]
         port: u16,
     },
@@ -195,8 +195,10 @@ pub enum Command {
         #[arg(help = "The id52 to which this bridge will forward incoming TCP request.")]
         proxy_target: String,
         #[arg(
-            help = "The port on which this bridge will listen for incoming TCP requests.",
-            default_value = "8081"
+            long,
+            short('p'),
+            help = "The port on which this bridge will listen for incoming TCP requests. If you pass 0, it will bind to a random port.",
+            default_value = "0"
         )]
         port: u16,
     },


### PR DESCRIPTION
- `malai {http, tcp}-bridge`: `port` is now optional, if you don't provide a
  port, it will be assigned a random port.
- breaking: `malai tcp-bridge` accepts port using `--port` or `-p` flag. Earlier
  it used to accept the port as second positional parameter. This is breaking
  change and is done to be consistent with `malai http-bridge` command.