### PR TITLE
`tokio::{select, net::TcpListener}` not mixing well

### DIFF
--- a/malai/src/http_bridge.rs
+++ b/malai/src/http_bridge.rs
@@ -21,40 +21,59 @@ pub async fn http_bridge(
 
     let peer_connections = kulfi_utils::PeerStreamSenders::default();
 
-    let mut g = graceful.clone();
+    // let mut g = graceful.clone();
 
     loop {
         tracing::trace!("waiting for connection");
-        tokio::select! {
-            () = graceful.cancelled() => {
-                tracing::info!("Stopping control server.");
-                break;
-            }
-            r = g.show_info() => {
-                match r {
-                    Ok(_) => {
-                        println!("Listening on http://127.0.0.1:{port}");
-                        println!("Press ctrl+c again to exit.");
-                    }
-                    Err(e) => {
-                        tracing::error!("failed to show info: {e:?}");
-                    }
-                }
-            }
-            Ok((stream, _addr)) = listener.accept() => {
+
+        match listener.accept().await {
+            Ok((stream, _addr)) => {
                 tracing::info!("got connection");
                 let g = graceful.clone();
                 let peer_connections = peer_connections.clone();
                 let proxy_target = proxy_target.clone();
                 graceful.spawn(async move {
                     let self_endpoint = malai::global_iroh_endpoint().await;
-                    handle_connection(self_endpoint, stream, g, peer_connections, proxy_target).await
+                    handle_connection(self_endpoint, stream, g, peer_connections, proxy_target)
+                        .await
                 });
             }
-            Err(e) = listener.accept() => {
+            Err(e) => {
                 tracing::error!("failed to accept: {e:?}");
-            },
+                break;
+            }
         }
+
+        // tokio::select! {
+        //     () = graceful.cancelled() => {
+        //         tracing::info!("Stopping control server.");
+        //         break;
+        //     }
+        //     r = g.show_info() => {
+        //         match r {
+        //             Ok(_) => {
+        //                 println!("Listening on http://127.0.0.1:{port}");
+        //                 println!("Press ctrl+c again to exit.");
+        //             }
+        //             Err(e) => {
+        //                 tracing::error!("failed to show info: {e:?}");
+        //             }
+        //         }
+        //     }
+        //     Ok((stream, _addr)) = listener.accept() => {
+        //         tracing::info!("got connection");
+        //         let g = graceful.clone();
+        //         let peer_connections = peer_connections.clone();
+        //         let proxy_target = proxy_target.clone();
+        //         graceful.spawn(async move {
+        //             let self_endpoint = malai::global_iroh_endpoint().await;
+        //             handle_connection(self_endpoint, stream, g, peer_connections, proxy_target).await
+        //         });
+        //     }
+        //     Err(e) = listener.accept() => {
+        //         tracing::error!("failed to accept: {e:?}");
+        //     },
+        // }
     }
 
     Ok(())

--- a/malai/src/http_bridge.rs
+++ b/malai/src/http_bridge.rs
@@ -23,12 +23,14 @@ pub async fn http_bridge(
 
     let mut g = graceful.clone();
     let g2 = graceful.clone();
-    g.spawn(async move { listener_loop(listener, g2, peer_connections, proxy_target).await });
+    let listener_handle =
+        g.spawn(async move { listener_loop(listener, g2, peer_connections, proxy_target).await });
 
     loop {
         tokio::select! {
             () = graceful.cancelled() => {
                 tracing::info!("Stopping control server.");
+                listener_handle.abort();
                 break;
             }
             r = g.show_info() => {


### PR DESCRIPTION
We have intermitted 502 issue in http bridge, closes #60, this PR is an attempt to fix it. 

By process of elimination I found that `tokio::select {}` is the issue, its quite odd because we seem to be doing everything correctly as per docs, and select is designed for this precise use case, so its a bug in tokio::select itself. The fact that after I remove select from the tcp stream part, the problem goes away (in my limited testing, running `curl` repeatedly, not even doing concurrent testing yet), kind of proves my theory.

I also found our graceful shutdown for http bridge was buggy, I have fixed that too here. 